### PR TITLE
Add report template feature

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -148,6 +148,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.queries.api import QueryRestApi
         from superset.queries.saved_queries.api import SavedQueryRestApi
         from superset.reports.api import ReportScheduleRestApi
+        from superset.report_templates.api import ReportTemplateRestApi
         from superset.reports.logs.api import ReportExecutionLogRestApi
         from superset.row_level_security.api import RLSRestApi
         from superset.security.api import RoleRestAPI, SecurityRestApi
@@ -220,6 +221,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_api(ImportExportRestApi)
         appbuilder.add_api(QueryRestApi)
         appbuilder.add_api(ReportScheduleRestApi)
+        appbuilder.add_api(ReportTemplateRestApi)
         appbuilder.add_api(ReportExecutionLogRestApi)
         appbuilder.add_api(RLSRestApi)
         appbuilder.add_api(SavedQueryRestApi)

--- a/superset/migrations/versions/2025-06-07_00-00_b4757fa23b89_add_report_templates_table.py
+++ b/superset/migrations/versions/2025-06-07_00-00_b4757fa23b89_add_report_templates_table.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add report templates table
+
+Revision ID: b4757fa23b89
+Revises: 363a9b1e8992
+Create Date: 2025-06-07 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from superset.migrations.shared.utils import create_table
+
+# revision identifiers, used by Alembic.
+revision = "b4757fa23b89"
+down_revision = "363a9b1e8992"
+
+
+def upgrade() -> None:
+    create_table(
+        "report_templates",
+        sa.Column("created_on", sa.DateTime(), nullable=True),
+        sa.Column("changed_on", sa.DateTime(), nullable=True),
+        sa.Column("name", sa.String(length=250), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("dataset_id", sa.Integer(), sa.ForeignKey("tables.id"), nullable=False),
+        sa.Column("template_content", sa.Text(), nullable=False),
+        sa.Column("changed_by_fk", sa.Integer(), nullable=True),
+        sa.Column("created_by_fk", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("report_templates")

--- a/superset/report_templates/models.py
+++ b/superset/report_templates/models.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from flask_appbuilder import Model
+from sqlalchemy import Column, Integer, String, Text, ForeignKey
+from sqlalchemy.orm import relationship
+
+from superset.models.helpers import AuditMixinNullable
+from superset.connectors.sqla.models import SqlaTable
+
+
+class ReportTemplate(Model, AuditMixinNullable):
+    """Template for generating reports based on datasets."""
+
+    __tablename__ = "report_templates"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(250), nullable=False)
+    description = Column(Text)
+    dataset_id = Column(Integer, ForeignKey("tables.id"), nullable=False)
+    template_content = Column(Text, nullable=False)
+
+    dataset = relationship(SqlaTable, foreign_keys=[dataset_id])
+
+    def __repr__(self) -> str:
+        return f"ReportTemplate<{self.id} {self.name}>"


### PR DESCRIPTION
## Summary
- add new ReportTemplate model for storing report templates
- provide REST API to list templates and generate reports
- register API and create Alembic migration

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba6ff2fa0832393611671559401dd