### PR TITLE
Add report template management API

### DIFF
--- a/superset-frontend/cypress-base/cypress/utils/urls.ts
+++ b/superset-frontend/cypress-base/cypress/utils/urls.ts
@@ -28,5 +28,6 @@ export const DATABASE_LIST = '/databaseview/list';
 export const DATASET_LIST_PATH = 'tablemodelview/list';
 export const ALERT_LIST = '/alert/list/';
 export const REPORT_LIST = '/report/list/';
+export const REPORT_TEMPLATE_LIST = '/report_template/list/';
 export const LOGIN = '/login/';
 export const REGISTER = '/register/';

--- a/superset-frontend/src/features/reportTemplates/UploadReportTemplateModal.tsx
+++ b/superset-frontend/src/features/reportTemplates/UploadReportTemplateModal.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { t, SupersetClient } from '@superset-ui/core';
+import { Modal, Input, Button } from '@superset-ui/core/components';
+
+interface UploadReportTemplateModalProps {
+  show: boolean;
+  onHide: () => void;
+  onUpload: () => void;
+  addDangerToast: (msg: string) => void;
+  addSuccessToast: (msg: string) => void;
+}
+
+export default function UploadReportTemplateModal({
+  show,
+  onHide,
+  onUpload,
+  addDangerToast,
+  addSuccessToast,
+}: UploadReportTemplateModalProps) {
+  const [name, setName] = useState('');
+  const [datasetId, setDatasetId] = useState('');
+  const [description, setDescription] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+
+  const reset = () => {
+    setName('');
+    setDatasetId('');
+    setDescription('');
+    setFile(null);
+  };
+
+  const handleUpload = () => {
+    if (!file || !name || !datasetId) {
+      addDangerToast(t('All fields are required'));
+      return;
+    }
+    const form = new FormData();
+    form.append('template', file);
+    form.append('name', name);
+    form.append('dataset_id', datasetId);
+    if (description) form.append('description', description);
+    SupersetClient.post({
+      endpoint: '/api/v1/report_template/',
+      postPayload: form,
+      stringify: false,
+    })
+      .then(() => {
+        addSuccessToast(t('Template uploaded'));
+        reset();
+        onUpload();
+        onHide();
+      })
+      .catch(err => {
+        addDangerToast(t('Failed to upload template: %s', err.message));
+      });
+  };
+
+  return (
+    <Modal
+      show={show}
+      title={t('Add report template')}
+      onHide={onHide}
+      footer={
+        <div>
+          <Button buttonStyle="secondary" onClick={onHide}>
+            {t('Cancel')}
+          </Button>
+          <Button buttonStyle="primary" onClick={handleUpload}>
+            {t('Upload')}
+          </Button>
+        </div>
+      }
+    >
+      <div className="field">
+        <label htmlFor="template-name">{t('Name')}</label>
+        <Input
+          id="template-name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="template-dataset">{t('Dataset id')}</label>
+        <Input
+          id="template-dataset"
+          value={datasetId}
+          onChange={e => setDatasetId(e.target.value)}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="template-desc">{t('Description')}</label>
+        <Input.TextArea
+          id="template-desc"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+        />
+      </div>
+      <div className="field">
+        <input
+          type="file"
+          accept=".odt"
+          onChange={e => setFile(e.target.files?.[0] || null)}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/superset-frontend/src/features/reportTemplates/index.ts
+++ b/superset-frontend/src/features/reportTemplates/index.ts
@@ -1,1 +1,2 @@
 export { default as ReportTemplateModal } from './ReportTemplateModal';
+export { default as UploadReportTemplateModal } from './UploadReportTemplateModal';

--- a/superset-frontend/src/pages/ReportTemplateList/index.tsx
+++ b/superset-frontend/src/pages/ReportTemplateList/index.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useMemo, useState } from 'react';
+import { t, SupersetClient } from '@superset-ui/core';
+import withToasts from 'src/components/MessageToasts/withToasts';
+import SubMenu, { SubMenuProps } from 'src/features/home/SubMenu';
+import {
+  ListView,
+  ListViewActionsBar,
+  type ListViewActionProps,
+} from 'src/components';
+
+import { Icons } from '@superset-ui/core/components/Icons';
+import { UploadReportTemplateModal } from 'src/features/reportTemplates';
+
+interface TemplateObject {
+  id: number;
+  name: string;
+  description: string;
+  dataset_id: number;
+}
+
+interface TemplateListProps {
+  addDangerToast: (msg: string) => void;
+  addSuccessToast: (msg: string) => void;
+}
+
+function ReportTemplateList({ addDangerToast, addSuccessToast }: TemplateListProps) {
+  const [data, setData] = useState<TemplateObject[]>([]);
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+
+  const fetchData = useCallback(({ pageIndex, pageSize }: any) => {
+    setLoading(true);
+    const offset = pageIndex * pageSize;
+    SupersetClient.get({
+      endpoint: `/api/v1/report_template/?limit=${pageSize}&offset=${offset}`,
+    })
+      .then(({ json }) => {
+        setData(json.result);
+        setCount(json.count ?? json.result.length);
+      })
+      .catch(err => {
+        addDangerToast(t('Error loading templates: %s', err.message));
+      })
+      .finally(() => setLoading(false));
+  }, [addDangerToast]);
+
+  const handleDownload = (id: number) => {
+    SupersetClient.get({
+      endpoint: `/api/v1/report_template/${id}/download`,
+      parseMethod: 'raw',
+    })
+      .then((resp: Response) => resp.blob())
+      .then(blob => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'template.odt';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        window.URL.revokeObjectURL(url);
+      })
+      .catch(err => {
+        addDangerToast(t('Failed to download template: %s', err.message));
+      });
+  };
+
+  const handleGenerate = (id: number) => {
+    SupersetClient.post({
+      endpoint: `/api/v1/report_template/${id}/generate`,
+      parseMethod: 'raw',
+    })
+      .then((resp: Response) => resp.blob())
+      .then(blob => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'report.odt';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        window.URL.revokeObjectURL(url);
+      })
+      .catch(err => {
+        addDangerToast(t('Failed to generate report: %s', err.message));
+      });
+  };
+
+  const handleDelete = (id: number) => {
+    SupersetClient.delete({ endpoint: `/api/v1/report_template/${id}` })
+      .then(() => {
+        addSuccessToast(t('Deleted'));
+        fetchData({ pageIndex: 0, pageSize: 25 });
+      })
+      .catch(err => {
+        addDangerToast(t('Failed to delete: %s', err.message));
+      });
+  };
+
+  const columns = useMemo(
+    () => [
+      {
+        accessor: 'name',
+        Header: t('Name'),
+        id: 'name',
+      },
+      {
+        accessor: 'description',
+        Header: t('Description'),
+        id: 'description',
+      },
+      {
+        accessor: 'dataset_id',
+        Header: t('Dataset ID'),
+        id: 'dataset_id',
+      },
+      {
+        Cell: ({ row: { original } }: any) => {
+          const actions = [
+            {
+              label: 'download',
+              tooltip: t('Download'),
+              placement: 'bottom',
+              icon: 'DownloadOutlined',
+              onClick: () => handleDownload(original.id),
+            },
+            {
+              label: 'edit',
+              tooltip: t('Edit'),
+              placement: 'bottom',
+              icon: 'EditOutlined',
+              onClick: () => handleDownload(original.id),
+            },
+            {
+              label: 'generate',
+              tooltip: t('Generate report'),
+              placement: 'bottom',
+              icon: 'FileTextOutlined',
+              onClick: () => handleGenerate(original.id),
+            },
+            {
+              label: 'delete',
+              tooltip: t('Delete'),
+              placement: 'bottom',
+              icon: 'DeleteOutlined',
+              onClick: () => handleDelete(original.id),
+            },
+          ];
+          return <ListViewActionsBar actions={actions as ListViewActionProps[]} />;
+        },
+        Header: t('Actions'),
+        id: 'actions',
+        disableSortBy: true,
+      },
+    ],
+    [],
+  );
+
+  const menuData: SubMenuProps = { name: t('Report templates') };
+  menuData.buttons = [
+    {
+      name: (
+        <>
+          <Icons.PlusOutlined iconSize="m" />
+          {t('Report template')}
+        </>
+      ),
+      buttonStyle: 'primary',
+      onClick: () => setShowModal(true),
+    },
+  ];
+
+  return (
+    <>
+      <SubMenu {...menuData} />
+      <UploadReportTemplateModal
+        show={showModal}
+        onHide={() => setShowModal(false)}
+        onUpload={() => fetchData({ pageIndex: 0, pageSize: 25 })}
+        addDangerToast={addDangerToast}
+        addSuccessToast={addSuccessToast}
+      />
+      <ListView<TemplateObject>
+        className="report-template-list"
+        columns={columns}
+        count={count}
+        data={data}
+        fetchData={fetchData}
+        loading={loading}
+        pageSize={25}
+      />
+    </>
+  );
+}
+
+export default withToasts(ReportTemplateList);

--- a/superset-frontend/src/views/routes.tsx
+++ b/superset-frontend/src/views/routes.tsx
@@ -64,6 +64,13 @@ const CssTemplateList = lazy(
     ),
 );
 
+const ReportTemplateList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "ReportTemplateList" */ 'src/pages/ReportTemplateList'
+    ),
+);
+
 const DashboardList = lazy(
   () =>
     import(/* webpackChunkName: "DashboardList" */ 'src/pages/DashboardList'),
@@ -211,6 +218,10 @@ export const routes: Routes = [
   {
     path: '/csstemplatemodelview/list/',
     Component: CssTemplateList,
+  },
+  {
+    path: '/report_template/list/',
+    Component: ReportTemplateList,
   },
   {
     path: '/annotationlayer/list/',

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -331,6 +331,16 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category_icon="",
         )
 
+        appbuilder.add_link(
+            "Report Templates",
+            label=__("Report Templates"),
+            href=f"{app_root}/report_template/list/",
+            icon="fa-file-text",
+            category="Manage",
+            category_label=__("Manage"),
+            category_icon="",
+        )
+
         #
         # Setup views with no menu
         #

--- a/superset/report_templates/api.py
+++ b/superset/report_templates/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from flask import Response, send_file
+from flask import Response, send_file, request
 from flask_appbuilder.api import expose, protect, safe
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import lazy_gettext as _
@@ -15,7 +15,12 @@ from io import BytesIO
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.extensions import event_logger
 from superset.utils import core as utils
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from werkzeug.utils import secure_filename
+from superset.views.base_api import (
+    BaseSupersetModelRestApi,
+    statsd_metrics,
+    requires_form_data,
+)
 
 from .models import ReportTemplate
 
@@ -25,7 +30,13 @@ logger = logging.getLogger(__name__)
 class ReportTemplateRestApi(BaseSupersetModelRestApi):
     datamodel = SQLAInterface(ReportTemplate)
 
-    include_route_methods = {RouteMethod.GET_LIST, "generate"}
+    include_route_methods = {
+        RouteMethod.GET_LIST,
+        RouteMethod.POST,
+        RouteMethod.DELETE,
+        "generate",
+        "download",
+    }
     class_permission_name = "ReportTemplate"
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
 
@@ -36,22 +47,112 @@ class ReportTemplateRestApi(BaseSupersetModelRestApi):
 
     openapi_spec_tag = "Report Templates"
 
-    @expose("/", methods=("GET",))
+
+    @expose("/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
-    def get_list(self) -> Response:
-        templates = self.datamodel.session.query(ReportTemplate).all()
-        result = [
-            {
-                "id": t.id,
-                "name": t.name,
-                "description": t.description,
-                "dataset_id": t.dataset_id,
-            }
-            for t in templates
-        ]
-        return self.response(200, result=result)
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
+        log_to_statsd=False,
+    )
+    @requires_form_data
+    def post(self) -> Response:
+        """Upload a new report template."""
+        file = request.files.get("template")
+        name = request.form.get("name")
+        dataset_id = request.form.get("dataset_id", type=int)
+        description = request.form.get("description")
+        if not file or not name or not dataset_id:
+            return self.response_400(message="Missing required fields")
+        cfg = current_app.config
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=cfg.get("REPORT_TEMPLATE_S3_ENDPOINT"),
+            aws_access_key_id=cfg.get("REPORT_TEMPLATE_S3_ACCESS_KEY"),
+            aws_secret_access_key=cfg.get("REPORT_TEMPLATE_S3_SECRET_KEY"),
+        )
+        key = f"templates/{utils.shortid()}_{secure_filename(file.filename)}"
+        try:
+            s3.upload_fileobj(file, cfg.get("REPORT_TEMPLATE_S3_BUCKET"), key)
+            template = ReportTemplate(
+                name=name,
+                description=description,
+                dataset_id=dataset_id,
+                template_path=key,
+            )
+            self.datamodel.session.add(template)
+            self.datamodel.session.commit()
+            return self.response(201, id=template.id)
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.error("Error uploading template: %s", ex, exc_info=True)
+            return self.response(500, message=str(ex))
+
+    @expose("/<int:pk>", methods=("DELETE",))
+    @protect()
+    @safe
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete",
+        log_to_statsd=False,
+    )
+    def delete(self, pk: int) -> Response:
+        """Delete a report template."""
+        template = self.datamodel.session.get(ReportTemplate, pk)
+        if not template:
+            return self.response_404()
+        cfg = current_app.config
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=cfg.get("REPORT_TEMPLATE_S3_ENDPOINT"),
+            aws_access_key_id=cfg.get("REPORT_TEMPLATE_S3_ACCESS_KEY"),
+            aws_secret_access_key=cfg.get("REPORT_TEMPLATE_S3_SECRET_KEY"),
+        )
+        try:
+            s3.delete_object(
+                Bucket=cfg.get("REPORT_TEMPLATE_S3_BUCKET"),
+                Key=template.template_path,
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Could not delete template file", exc_info=True)
+        self.datamodel.session.delete(template)
+        self.datamodel.session.commit()
+        return self.response(200, message="OK")
+
+    @expose("/<int:pk>/download", methods=("GET",))
+    @protect()
+    @safe
+    @statsd_metrics
+    def download(self, pk: int) -> Response:
+        """Download the template file."""
+        template = self.datamodel.session.get(ReportTemplate, pk)
+        if not template:
+            return self.response_404()
+        cfg = current_app.config
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=cfg.get("REPORT_TEMPLATE_S3_ENDPOINT"),
+            aws_access_key_id=cfg.get("REPORT_TEMPLATE_S3_ACCESS_KEY"),
+            aws_secret_access_key=cfg.get("REPORT_TEMPLATE_S3_SECRET_KEY"),
+        )
+        try:
+            obj = s3.get_object(
+                Bucket=cfg.get("REPORT_TEMPLATE_S3_BUCKET"),
+                Key=template.template_path,
+            )
+            data = obj["Body"].read()
+            buffer = BytesIO(data)
+            buffer.seek(0)
+            filename = secure_filename(template.name or "template") + ".odt"
+            return send_file(
+                buffer,
+                mimetype="application/vnd.oasis.opendocument.text",
+                as_attachment=True,
+                download_name=filename,
+            )
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.error("Error downloading template: %s", ex, exc_info=True)
+            return self.response(500, message=str(ex))
 
     @expose("/<int:pk>/generate", methods=("POST",))
     @protect()


### PR DESCRIPTION
## Summary
- enable pagination for listing report templates
- allow uploading new report templates
- support deleting and downloading templates
- add UI page to manage report templates

## Testing
- `python -m py_compile superset/report_templates/api.py`


------
https://chatgpt.com/codex/tasks/task_e_686ba8fabed48323861454b90a76d38d