### PR TITLE
feat: add remote user auth

### DIFF
--- a/superset/security/__init__.py
+++ b/superset/security/__init__.py
@@ -15,3 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 from superset.security.manager import SupersetSecurityManager  # noqa: F401
+from superset.security.remote_user import CustomSecurityManager  # noqa: F401

--- a/superset/security/remote_user.py
+++ b/superset/security/remote_user.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Remote user security manager."""
+
+from flask_appbuilder.security.manager import AUTH_REMOTE_USER
+
+from superset.security.manager import SupersetSecurityManager
+
+
+class CustomSecurityManager(SupersetSecurityManager):
+    """Security manager that uses :class:`AuthRemoteUserView`."""
+
+    def register_views(self) -> None:  # type: ignore[override]
+        """Register the appropriate authentication views."""
+        if self.auth_type == AUTH_REMOTE_USER:
+            from superset.views.auth import AuthRemoteUserView, SupersetRegisterUserView
+
+            self.auth_view = self.appbuilder.add_view_no_menu(AuthRemoteUserView)
+            self.registeruser_view = self.appbuilder.add_view_no_menu(
+                SupersetRegisterUserView
+            )
+            super().register_views()
+        else:
+            super().register_views()

--- a/superset/views/auth.py
+++ b/superset/views/auth.py
@@ -17,10 +17,11 @@
 
 from typing import Optional
 
-from flask import g, redirect
+from flask import g, redirect, request, abort
 from flask_appbuilder import expose
 from flask_appbuilder.security.decorators import no_cache
 from flask_appbuilder.security.views import AuthView, WerkzeugResponse
+from flask_login import login_user
 
 from superset.views.base import BaseSupersetView
 
@@ -44,3 +45,26 @@ class SupersetRegisterUserView(BaseSupersetView):
     @no_cache
     def register(self) -> WerkzeugResponse:
         return super().render_app_template()
+
+
+class AuthRemoteUserView(SupersetAuthView):
+    """Authenticate users based on ``REMOTE_USER``."""
+
+    @expose("/")
+    @no_cache
+    def login(self, provider: Optional[str] = None) -> WerkzeugResponse:  # type: ignore[override]
+        """Authenticate the user from ``REMOTE_USER`` and redirect."""
+
+        if g.user is not None and g.user.is_authenticated:
+            return redirect(self.appbuilder.get_url_for_index)
+
+        remote_user = request.environ.get("REMOTE_USER")
+        if not remote_user:
+            return abort(401)
+
+        user = self.appbuilder.sm.auth_user_remote(remote_user)
+        if not user:
+            return abort(401)
+
+        login_user(user)
+        return redirect(self.appbuilder.get_url_for_index)


### PR DESCRIPTION
## Summary
- add AuthRemoteUserView for REMOTE_USER authentication
- expose CustomSecurityManager for remote user auth

## Testing
- `pytest tests/unit_tests/security/remote_user_middleware_test.py::test_remote_user_header_copied -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pre-commit run --files superset/views/auth.py superset/security/remote_user.py superset/security/__init__.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecc135d7483239bd122955346901d